### PR TITLE
Added extra host descritpion for graph title

### DIFF
--- a/icecast2_all
+++ b/icecast2_all
@@ -30,6 +30,8 @@
 # Hostname of Icecast server
 # Just canonical name, no http:// nor ending /, include port number if required
 host = "localhost:8000"
+# inset some descriptive name, to distinguish server on multiple plugin instances
+host_desc = "My icecast server"
 # Username and password to the administration panel
 username = "admin"
 password = "changemenow"
@@ -76,7 +78,7 @@ def ic2xml():
                 listeners, name = sourcelist[source]
                 print((source + ".value " + listeners))
         elif sys.argv[1] == "config":
-            print ("graph_title Total number of listeners")
+            print ("graph_title Total number of listeners on " + host_desc)
             print ("graph_vlabel listeners")
             print ("graph_category Icecast")
             print ("totallisteners.label Total number of listeners")


### PR DESCRIPTION
Useful to distinguish various icecast servers, for example you make 4 copies of the plugin with differnet names and custom hosts and you want to also add custom title to each graph to distinguish them.
